### PR TITLE
Display options down first, then across

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,14 @@ select element interchangebly.
 string value with description or null for no description of tile.
 Another way to define tile description is to set `data-description` attribute on corresponding option element. This attribute value has higher priority over description callback which mean it overrides it and callback function won't be even called for this element.
 
+8.  `layout`
+	* **default value**: "row"
+	* **type**: string
+	* **valid values**: "row", "column"
+	* **description**:
+
+	Specifies whether the options should display across, then down or down, then across. When "row" is specified (the default behavior) options will display across, then down. When "column" is specified, options will display down, then across.
+
 ## Methods
 
 1. `disable`

--- a/js/bootstrap-tile-multiselect.js
+++ b/js/bootstrap-tile-multiselect.js
@@ -26,7 +26,8 @@
             "uncheckIcon": function() { return "glyphicon glyphicon-unchecked"; },
             "limit": false,
             "description": null,
-            "label": function(e, v, t) { return t; }
+            "label": function(e, v, t) { return t; },
+            "layout": "row"
         },
         callbacks: [
             'description',
@@ -43,7 +44,43 @@
             var num = 0;
             var tileCol = 12 / tileMS.options.columns;
             var row = null;
-            $('option', this.$select).each(function() {
+            let tiles = new Array();
+            if (tileMS.options.layout === "column") {
+                let columnLengths = [];
+                let dataLength = $('option', this.$select).length;
+                if (dataLength % tileMS.options.columns === 0) {
+                    for (let i = 0; i < tileMS.options.columns; i++) {
+                        columnLengths.push(dataLength / tileMS.options.columns);
+                    }
+                } else {                    
+                    let columnLength = Math.floor(dataLength / tileMS.options.columns * 1) / 1;
+                    for (let i = 0; i < tileMS.options.columns; i++) {                        
+                        if (i < dataLength % tileMS.options.columns) {
+                            columnLengths.push(columnLength + 1);
+                        } else {
+                            columnLengths.push(columnLength);
+                        }
+                    }
+                }
+                
+                var addedIndexes = [];
+                for (let i = 0; i < columnLengths[0]; i++) {
+                    let index = i;
+
+                    for (let c = 0; c < tileMS.options.columns; c++) {
+                        if (addedIndexes.indexOf(index) === -1) {
+                            tiles.push($('option', this.$select)[index]);
+                            addedIndexes.push(index);
+                            index += columnLengths[c];
+                        }
+                    }
+                }
+            }
+            else {
+                tiles = $('option', this.$select);
+            }
+
+            $.each(tiles, function () {
                 if (num++ % tileMS.options.columns === 0) {
                     row = $('<div class="row btm-row"></div>');
                     tileMS.$container.append(row);


### PR DESCRIPTION
The code could probably be cleaned up some more, but the intent was to display options down, then over, as opposed to over, then down.

For example, if you were listing US states in the current format they'd appear:
Alabama -> Alaska -> Arizona -> Arkansas, etc.

With the new (togglable) format they'd appear:
Alabama
|
Alaska
|
Arizona
|
Arkansas

The default remains the same so it's not a breaking change, but it allowed us to do what we needed to do with it.